### PR TITLE
fixing double next Head tag

### DIFF
--- a/src/containers/MetaInfo.tsx
+++ b/src/containers/MetaInfo.tsx
@@ -1,25 +1,23 @@
-import Head from 'next/head';
-
 export function MetaInfo() {
-    return (
-        <Head>
-            <title>Bikash Das</title>
-            <meta
-                name="viewport"
-                content="initial-scale=1.0, width=device-width, shrink-to-fit=no"
-            />
-            <meta property="og:title" content="Biaksh Das" />
-            <meta property="og:url" content="https://www.bikashdas.dev" />
-            <meta property="og:type" content="profile" />
-            <meta
-                property="og:image"
-                content="https://www.bikashdas.dev/favicon.svg"
-            />
-            <link rel="icon" type="image/svg" href="/favicon.svg" />
-            <meta
-                name="description"
-                content="Bikash Das is a software engineer who is skilled in web development including frontend and backend technologies and is very skilled in JavaScript, TypeScript, React, Node.js, Nest.js and more"
-            ></meta>
-        </Head>
-    );
+  return (
+    <>
+      <title>Bikash Das</title>
+      <meta
+        name="viewport"
+        content="initial-scale=1.0, width=device-width, shrink-to-fit=no"
+      />
+      <meta property="og:title" content="Biaksh Das" />
+      <meta property="og:url" content="https://www.bikashdas.dev" />
+      <meta property="og:type" content="profile" />
+      <meta
+        property="og:image"
+        content="https://www.bikashdas.dev/favicon.svg"
+      />
+      <link rel="icon" type="image/svg" href="/favicon.svg" />
+      <meta
+        name="description"
+        content="Bikash Das is a software engineer who is skilled in web development including frontend and backend technologies and is very skilled in JavaScript, TypeScript, React, Node.js, Nest.js and more"
+      ></meta>
+    </>
+  );
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,37 +2,19 @@ import { MetaInfo } from '@/containers/MetaInfo';
 import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
 
 class MyDocument extends Document {
-    static async getInitialProps(ctx: DocumentContext) {
-        const originalRenderPage = ctx.renderPage;
-
-        // Run the React rendering logic synchronously
-        ctx.renderPage = () =>
-            originalRenderPage({
-                // Useful for wrapping the whole react tree
-                enhanceApp: (App: any) => App,
-                // Useful for wrapping in a per-page basis
-                enhanceComponent: (Component: any) => Component,
-            });
-
-        // Run the parent `getInitialProps`, it now includes the custom `renderPage`
-        const initialProps = await Document.getInitialProps(ctx);
-
-        return initialProps;
-    }
-
-    render() {
-        return (
-            <Html lang="en-us">
-                <Head>
-                    <MetaInfo />
-                </Head>
-                <body>
-                    <Main />
-                    <NextScript />
-                </body>
-            </Html>
-        );
-    }
+  render() {
+    return (
+      <Html lang="en-us">
+        <Head>
+          <MetaInfo />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
 }
 
 export default MyDocument;


### PR DESCRIPTION
## Summary by Sourcery

Fix the issue of double 'Head' tags by removing the 'Head' component from MetaInfo and simplifying the component structure.

Bug Fixes:
- Remove duplicate usage of the 'Head' component in the MetaInfo component to prevent rendering issues.

Enhancements:
- Simplify the MetaInfo component by removing the 'Head' wrapper and using React fragments instead.